### PR TITLE
Got rid of the unusable grammar.map function as it became clear that …

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,6 +21,9 @@ grammar = [nouns, pronouns, verbs, tenses, determiners, prepositions];
 
 languages = ["English", "German", "Japanese"];
 
+
+
+
 # make all of these just 'word' but then filter for route with category, or make join table?
 
 
@@ -67,14 +70,6 @@ prepositions.map{
     )
 }
 
-# grammar.map{
-#     |part_of_speech_dictionary| part_of_speech_dictionary.map{
-#         |entry| Word.create(
-#             english: entry,
-#             category: part_of_speech_dictionary,
-#         )
-#     }
-# }
 
 languages.map{
     |language| Language.create(


### PR DESCRIPTION
…going that route would potentially lessen amount of loops for code, but would also require more time and be convoluted code in order to properly label the type of word when creating the Word instance for each mini dictionary. Re ran seed file, appropriately to fix issues and mis-entered entries from grammar.map testing as well.